### PR TITLE
Add schema and seed SQL scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # SQLServer
+
+This repository provides basic SQL scripts for creating a sample schema and populating it with fake data.
+
+## Scripts
+
+- `create_schema.sql` – Creates the `Sales` schema with `Customers` and `Orders` tables.
+- `seed_data.sql` – Inserts example rows into the tables.
+
+## Usage
+
+1. Connect to a SQL Server instance using a tool like `sqlcmd` or SQL Server Management Studio.
+2. Run `create_schema.sql` to create the schema and tables.
+3. Run `seed_data.sql` to insert sample records for testing.

--- a/create_schema.sql
+++ b/create_schema.sql
@@ -1,0 +1,23 @@
+-- create_schema.sql
+-- This script creates the Sales schema and tables
+
+CREATE SCHEMA Sales;
+GO
+
+CREATE TABLE Sales.Customers (
+    CustomerID INT IDENTITY(1,1) PRIMARY KEY,
+    FirstName NVARCHAR(50) NOT NULL,
+    LastName NVARCHAR(50) NOT NULL,
+    Email NVARCHAR(100) NOT NULL,
+    CreatedAt DATETIME DEFAULT GETDATE()
+);
+GO
+
+CREATE TABLE Sales.Orders (
+    OrderID INT IDENTITY(1,1) PRIMARY KEY,
+    CustomerID INT NOT NULL,
+    OrderDate DATETIME DEFAULT GETDATE(),
+    Amount DECIMAL(10,2) NOT NULL,
+    CONSTRAINT FK_Orders_Customers FOREIGN KEY (CustomerID) REFERENCES Sales.Customers(CustomerID)
+);
+GO

--- a/seed_data.sql
+++ b/seed_data.sql
@@ -1,0 +1,17 @@
+-- seed_data.sql
+-- This script inserts sample data into the Sales schema
+
+INSERT INTO Sales.Customers (FirstName, LastName, Email)
+VALUES
+    ('John', 'Doe', 'john.doe@example.com'),
+    ('Jane', 'Smith', 'jane.smith@example.com'),
+    ('Alice', 'Jones', 'alice.jones@example.com');
+GO
+
+INSERT INTO Sales.Orders (CustomerID, OrderDate, Amount)
+VALUES
+    (1, DATEADD(day, -10, GETDATE()), 99.99),
+    (1, DATEADD(day, -5, GETDATE()), 149.50),
+    (2, GETDATE(), 200.00),
+    (3, GETDATE(), 50.00);
+GO


### PR DESCRIPTION
## Summary
- add `create_schema.sql` for Sales schema and tables
- add `seed_data.sql` for sample data
- expand README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b16abf44832e9c4f8b0d937feeb5